### PR TITLE
add composer image with xdebug

### DIFF
--- a/composer-xdebug/Dockerfile
+++ b/composer-xdebug/Dockerfile
@@ -1,0 +1,11 @@
+FROM composer:2.0 AS composer-build
+
+FROM php:7.4-fpm-alpine
+
+RUN apk --no-cache add pcre-dev ${PHPIZE_DEPS} \ 
+  && pecl install xdebug \
+  && docker-php-ext-enable xdebug \
+  && apk del pcre-dev ${PHPIZE_DEPS}
+
+ENV XDEBUG_MODE=coverage
+COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/composer-xdebug/README.md
+++ b/composer-xdebug/README.md
@@ -1,0 +1,1 @@
+This image contains composer and xdebug mainly used for running php tests with coverage reports

--- a/composer-xdebug/README.md
+++ b/composer-xdebug/README.md
@@ -1,1 +1,8 @@
 This image contains composer and xdebug mainly used for running php tests with coverage reports
+
+# Usage
+```bash
+export _tag=`date +%Y%m%d`
+docker build -t gcr.io/cloudkite-public/composer-xdebug:$_tag .
+docker push gcr.io/cloudkite-public/composer-xdebug:$_tag
+```


### PR DESCRIPTION
adding composer image with xdebug mainly for running php tests with coverage reports 