### PR TITLE
add kaniko-alpine image

### DIFF
--- a/kaniko-alpine/Dockerfile
+++ b/kaniko-alpine/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/kaniko-project/executor:v1.9.0
+
+FROM alpine
+COPY --from=0 /kaniko/executor /usr/local/bin/executor
+ENTRYPOINT ["executor"]

--- a/kaniko-alpine/README.md
+++ b/kaniko-alpine/README.md
@@ -1,0 +1,11 @@
+This image contains:
+* kaniko
+
+
+Kaniko official image uses scratch base image which makes it difficult for modification
+
+# Usage
+```bash
+export _tag=`date +%Y%m%d`
+docker build -t gcr.io/cloudkite-public/kaniko-alpine:$_tag .
+docker push gcr.io/cloudkite-public/kaniko-alpine:$_tag


### PR DESCRIPTION
Kaniko official image uses scratch base image which makes it difficult for modification.