### PR TITLE
cloudflared-alpine - ability to set db port explicitly

### DIFF
--- a/cloudflared-alpine/README.md
+++ b/cloudflared-alpine/README.md
@@ -7,10 +7,13 @@ Cloudflared binary on apline image
 Start script is used to start cloudflared processes that are then exposed locally within the container.
 
 required env vars:
-* INSTANCES (comma separated string)
+* BASE_PORT
+* INSTANCES - comma separated string.
+Will increment db port starting with ${BASE_PORT}.
+You can set port explicitly
+ex: `db_host_1,db_host_2:port,db_host_3`
 * CF_SERVICE_AUTH_ID
 * CF_SERVICE_AUTH_SECRET
-* BASE_PORT
 * TUNNEL_ADDRESS
 
 

--- a/cloudflared-alpine/start-script.sh
+++ b/cloudflared-alpine/start-script.sh
@@ -3,7 +3,11 @@ IFS=","
 ITER=0
 for instance in ${INSTANCES}
 do
-   cloudflared access tcp --id "${CF_SERVICE_AUTH_ID}" --secret "${CF_SERVICE_AUTH_SECRET}"  --hostname "${instance}" --url "tcp://${TUNNEL_ADDRESS:-127.0.0.1}:$(expr ${BASE_PORT} + ${ITER})"&
-   ITER=$(expr ${ITER} + 1)
+  if [[ $instance == *":"* ]]; then
+    cloudflared access tcp --id "${CF_SERVICE_AUTH_ID}" --secret "${CF_SERVICE_AUTH_SECRET}"  --hostname "${instance%:*}" --url "tcp://${TUNNEL_ADDRESS:-127.0.0.1}:${instance#*:}"&
+  else
+    cloudflared access tcp --id "${CF_SERVICE_AUTH_ID}" --secret "${CF_SERVICE_AUTH_SECRET}"  --hostname "${instance}" --url "tcp://${TUNNEL_ADDRESS:-127.0.0.1}:$(expr ${BASE_PORT} + ${ITER})"&
+    ITER=$(expr ${ITER} + 1)
+  fi
 done
 sleep infinity


### PR DESCRIPTION
Faced an issue where some of the databases needs to be deleted, meaning all dbs followed this db in `INSTANCES` env will get their port decreased by 1. 
To prevent this, can we add ability to set ports explicitly?

I do not want to add breaking changes here, so providing a compromise: now it is possible to have comma separated list of dbs among with pre-defined ports.

Tested using this mock:
```sh
IFS=","
ITER=0
INSTANCES="one,two:222,tree"
BASE_PORT=1
for instance in ${INSTANCES}
do
  if [[ $instance == *":"* ]]; then
    echo cloudflared access tcp --id "${CF_SERVICE_AUTH_ID}" --secret "${CF_SERVICE_AUTH_SECRET}"  --hostname "${instance%:*}" --url "tcp://${TUNNEL_ADDRESS:-127.0.0.1}:${instance#*:}"
  else
    echo cloudflared access tcp --id "${CF_SERVICE_AUTH_ID}" --secret "${CF_SERVICE_AUTH_SECRET}"  --hostname "${instance}" --url "tcp://${TUNNEL_ADDRESS:-127.0.0.1}:$(expr ${BASE_PORT} + ${ITER})"
     ITER=$(expr ${ITER} + 1)
  fi
done
```
output:
```sh
cloudflared access tcp --id  --secret  --hostname one --url tcp://127.0.0.1:1
cloudflared access tcp --id  --secret  --hostname two --url tcp://127.0.0.1:222
cloudflared access tcp --id  --secret  --hostname tree --url tcp://127.0.0.1:2
```