### PR TITLE
[cicd] update atlantis workflow

### DIFF
--- a/.github/workflows/atlantis-aws.yaml
+++ b/.github/workflows/atlantis-aws.yaml
@@ -1,17 +1,17 @@
 name: Publish atlantis-aws-image
 
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
 env:
   IMAGE_NAME: atlantis-aws
   GAR_LOCATION: us-central1
   PROJECT_NAME: cloudkite-public
   PROJECT_ID: 297731695546
   REPOSITORY: docker-images
-
-on:
-  workflow_dispatch:
-  push:
-    branches: [main]
-    paths: [atlantis-aws/**]
 
 jobs:
   publish:
@@ -21,21 +21,24 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: projects/${{ env.PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-oidc
           service_account: github-actions@${{ env.PROJECT_NAME }}.iam.gserviceaccount.com
+
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Docker configuration
         run: gcloud auth configure-docker $GAR_LOCATION-docker.pkg.dev --quiet
+
       - name: Build and push image
         working-directory: ${{ env.IMAGE_NAME }}
         run: |
-          export DATE=$(date +'%m%d%Y')
           docker build -f Dockerfile \
-            -t $GAR_LOCATION-docker.pkg.dev/$PROJECT_NAME/$REPOSITORY/$IMAGE_NAME:$DATE .
+            -t $GAR_LOCATION-docker.pkg.dev/$PROJECT_NAME/$REPOSITORY/$IMAGE_NAME:${{ github.ref_name}} .
           docker push -a $GAR_LOCATION-docker.pkg.dev/$PROJECT_NAME/$REPOSITORY/$IMAGE_NAME

--- a/atlantis-aws/README.md
+++ b/atlantis-aws/README.md
@@ -11,3 +11,7 @@ docker build -t us-central1-docker.pkg.dev/cloudkite-public/docker-images/atlant
              . && \
 docker push -a us-central1-docker.pkg.dev/cloudkite-public/docker-images/atlantis-aws
 ```
+
+## CICD
+
+The deployment for this image builds only on push of a tag to the repo. Please use the version of the atlantis image in the tag, e.g v0.33.0, for the image to be tagged as us-central1-docker.pkg.dev/cloudkite-public/docker-images/atlantis-aws:v0.33.0.


### PR DESCRIPTION
- run build on push tags,
- update action versions to latest,
- update readme

We need the image tags to match the versions in the official [releases](https://github.com/runatlantis/atlantis/releases)