### PR TITLE
deploy postgres client version 16

### DIFF
--- a/postgresclient-with-awscli/Dockerfile
+++ b/postgresclient-with-awscli/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:12-slim
+FROM ubuntu:24.10
 
-RUN apt update && apt install postgresql-client-15 awscli \ 
+RUN apt update && apt install postgresql-client-16 awscli \ 
     nano telnet apt-transport-https ca-certificates curl \
     gnupg-agent software-properties-common unzip less -y

--- a/postgresclient-with-awscli/README.md
+++ b/postgresclient-with-awscli/README.md
@@ -1,8 +1,13 @@
 # postgresclient-with-awscli
 
-This is a debian based image that contains:
+This is a debian/ubuntu based image that contains:
 * postgres client
 * awscli
+
+We use either debian or ubuntu, depending on which of the two has postgresql-client available in a stable release. References:
+
+- https://packages.debian.org/search?keywords=postgresql-client
+- https://launchpad.net/ubuntu/+search?text=postgresql-client
 
 ##  Usage
 ```bash
@@ -13,4 +18,4 @@ docker push us-central1-docker.pkg.dev/cloudkite-public/docker-images/postgrescl
 
 ## CICD
 
-The deployment for this image builds only on push of a tag formatted as `postgresclient-aws-*` to the repo. Please use the postgres and the debian version in the tag, e.g postgresclient-aws-15-5-bookworm, for the image to be tagged as us-central1-docker.pkg.dev/cloudkite-public/docker-images/postgresclient-aws:15-5-bookworm.
+The deployment for this image builds only on push of a tag formatted as `postgresclient-aws-*` to the repo. Please use the postgres and the debian/ubuntu version in the tag, e.g postgresclient-aws-15-5-bookworm, for the image to be tagged as us-central1-docker.pkg.dev/cloudkite-public/docker-images/postgresclient-aws:15-5-bookworm.


### PR DESCRIPTION
- deploys postgres v16 with awscli
   - As of current date only ubuntu 24 has postgresql client v16, so we change the base image to ubuntu and update the docs